### PR TITLE
Add ordering to portal

### DIFF
--- a/docs/pages/1-generate.md
+++ b/docs/pages/1-generate.md
@@ -205,7 +205,7 @@ docker run -v /tmp/another_base:/data \
 
 and your experiments will be copied fully there to still satisfy this condition, it is more redundant this way.
 
-Finally, before you generate your recipe, in the case that you want "hard coded" defaults (e.g., set as defaults for future users) read the [custom build](#custom-build) section below to learn about the variables that you can customize. If not, then rest assured that these values can be specified when a built container is started.
+Finally, before you generate your recipe, in the case that you want "hard coded" defaults (e.g., set as defaults for future users) read the [custom build](#custom-conriguration) section below to learn about the variables that you can customize. If not, then rest assured that these values can be specified when a built container is started.
 
 
 ## Container Generation
@@ -481,7 +481,8 @@ If you change the defaults, this means that any users that run your container (w
 
 If you leave these defaults, you (and the future users of your container) can then easily customize these variables when the container is started in the future. The risk of setting a default database like `sql` or `postgres` is that a user that doesn't know some credential needs to be defined won't be able to use the container. 
 
-The choice is up to you! For settings defaults, see the first section [default variables](#default-variables). For setting at runtime, see the second section [runtime variables](#runtime-variables).
+The choice is up to you! For settings defaults at build time, see the next section [default variables](#default-variables). For setting at runtime, see the next page for [starting your container](/expfactory/usage.html#start-the-container).
+
  
 ## Default Variables
 When you run a build with `vanessa/expfactory-builder` image, there are other command line options available pertaining to the database and study id. Try running `docker run vanessa/expfactory-builder build --help` to see usage. If you customize these variables, the container recipe generated will follow suit.
@@ -498,10 +499,18 @@ docker run -v /tmp/my-experiment:/data \
 
 Your other options are **sqlite**, **mysql**, and **postgres** all of which we recommend you specify when you start the image.
 
+### randomize
+By default, experiments will be selected in random order, and it's recommended to keep this. The other option will use the ordering of experiments as you've selected them. If you want a manually set order, then after you use the `expfactory-builder`, edit your Dockerfile by adding the following environment variable:
 
-## Identifiers
+```
+ENV EXPFACTORY_RANDOM true
+```
 
-**studyid**
+This variable can be easily changed at runtime via a checkbox, so it's not hugely important to set here.
+
+
+### studyid
+
 The Experiment Factory will generate a new unique ID for each participant with some study idenitifier prefix. The default is `expfactory`, meaning that my participants will be given identifiers `expfactory/0` through `expfactory/n`, and for a filesystem database, it will produce output files according to that schema:
 
 ```
@@ -523,12 +532,13 @@ docker run -v /tmp/my-experiment:/data \
 Again, we recommend that you leave this as general (or the default) and specify the study identifier at runtime. If you want to preserve a container to be integrated into an analysis exactly as is, then you would want to specify it at build.
 
 
-**output**
+### output
+
 You actually **don't** want to edit the recipe output file, since this happens inside the container
 (and you map a folder of your choice to it.) Note that it is a variable, however, if you need to use expfactory natively and want to specify a different location.
 
 
-### Expfactory wants Your Feedback!
+## Expfactory wants Your Feedback!
 The customization process is very important, because it will mean allowing you to select variable stimuli, lengths, or anything to make a likely general experiment specific to your use case. To help with this, @vsoch is looking for feedback about:
 
  - what kind of experiments (those provided in the library? generated with a build tool?) do you want to use

--- a/docs/pages/2-usage.md
+++ b/docs/pages/2-usage.md
@@ -121,14 +121,14 @@ for row in results:
 Each result row includes the table row id, the date, result content, and participant id.
 
 ```
->>> res[0]  # table result row index
+>>> row[0]  # table result row index
 1
 
->>> res[1]  # date
+>>> row[1]  # date
 '2017-11-18 17:26:30'
 
->>> res[2]  # data from experiment, json.loads needed
->>> json.loads(res[2])
+>>> row[2]  # data from experiment, json.loads needed
+>>> json.loads(row[2])
 [{ 
    'timing_post_trial': 100, 
    'exp_id': 'test-task', 

--- a/docs/pages/2-usage.md
+++ b/docs/pages/2-usage.md
@@ -15,7 +15,9 @@ Below, we will summarize the variables that can be set at runtime:
 | database      | the database to store response data | filesystem |
 | randomize     | present the experiments in random order  |  flag | 
 | no-randomize  | manually select the order of experiments  |  flag | 
+| experiments  | comma separated list of experiments (manual ordering)  |  [] | 
 | studyid | set the studyid at runtime  |  expfactory | * |
+
 
 
 ## Start the Container
@@ -41,6 +43,14 @@ Here is how to specify a different database, like sqlite
 docker run -v /tmp/my-experiment/data/:/scif/data \
            -d -p 80:80 \
            expfactory/experiments  --database sqlite start
+```
+
+Here is how to specify a "hard coded" ordering. If your container has experiments that you don't list, they will not be included:
+
+```
+docker run -v /tmp/my-experiment/data/:/scif/data \
+           -d -p 80:80 \
+           expfactory/experiments  --experiments test-test,tower-of-london start
 ```
 
 We will go into each database type in some detail.

--- a/docs/pages/2-usage.md
+++ b/docs/pages/2-usage.md
@@ -8,6 +8,15 @@ permalink: /usage
 # Using your Experiments Container
 If you've just finished [generating your experiments container](/expfactory/generate.html) (whether a custom build or pull of an already existing container) then you are ready to use it! 
 
+Below, we will summarize the variables that can be set at runtime:
+
+| Variable        | Description           | Default  | Options |
+| ------------- |:-------------:| -----:|
+| database      | the database to store response data | filesystem |
+| randomize     | present the experiments in random order  |  flag | 
+| no-randomize  | manually select the order of experiments  |  flag | 
+| studyid | set the studyid at runtime  |  expfactory | * |
+
 
 ## Start the Container
 It's most likely the case that your container's default is to save data to the file system, and use a study id of expfactory. This coincides to running with no extra arguments, but perhaps mapping the data folder:

--- a/docs/pages/2-usage.md
+++ b/docs/pages/2-usage.md
@@ -15,7 +15,7 @@ Below, we will summarize the variables that can be set at runtime:
 | database      | the database to store response data | filesystem |
 | randomize     | present the experiments in random order  |  flag | 
 | no-randomize  | manually select the order of experiments  |  flag | 
-| experiments  | comma separated list of experiments (manual ordering)  |  [] | 
+| experiments  | comma separated list of experiments to expose |  [] | 
 | studyid | set the studyid at runtime  |  expfactory | * |
 
 
@@ -45,7 +45,7 @@ docker run -v /tmp/my-experiment/data/:/scif/data \
            expfactory/experiments  --database sqlite start
 ```
 
-Here is how to specify a "hard coded" ordering. If your container has experiments that you don't list, they will not be included:
+Here is how to limit the experiments exposed in the portal. For example, you may have 30 installed in the container, but only want to reveal 3 for a session:
 
 ```
 docker run -v /tmp/my-experiment/data/:/scif/data \
@@ -53,7 +53,7 @@ docker run -v /tmp/my-experiment/data/:/scif/data \
            expfactory/experiments  --experiments test-test,tower-of-london start
 ```
 
-We will go into each database type in some detail.
+We are currently working on a "headless" start up that will allow for a pre-set ordering an other variables, and then skipping over the portal. Please let us know if you have feedback on this. We will go into each database type in some detail.
 
 
 ### filesystem

--- a/docs/pages/3-contribute.md
+++ b/docs/pages/3-contribute.md
@@ -40,7 +40,7 @@ The most basic experiment contribution could be a web form, an intermediate cont
  - **the experiment runs via a single file**: The server will be authenticating pages based on sessions and CSRF. For now, your experiment is required to run on a single page, meaning that the `POST` to save data comes from the same page where the experiment started.
  - **the experiment runs statically** When it finishes, it posts to `/finish`, and on successful POST redirects to `/next`.
  - (optional) documentation about any special variables that can be set in the Singularity build recipe environment section for it (more on this later).
- - **experiment completion** should have a POST of json data (`{"data": data}`) to `/save`. If successful, it navigates to `/next`. If not successful, data should be saved locally in the format of your choice (for preview and testing purposes).
+ - **experiment completion** should have a POST of json data (`{"data": data}`) to `/save`. If successful, it navigates to `/next`. If not successful, data should be saved locally in the format of your choice (for preview and testing purposes). The server will by default look for the post to have a `data` field and use it. If not found, it will use the entire `POST`.
 
 
 # The general steps

--- a/expfactory/database/relational.py
+++ b/expfactory/database/relational.py
@@ -92,7 +92,7 @@ def save_data(self,session, exp_id, content):
             content = content['data']
 
         print(content)
-        pickle.dump(content. open('/data/content.pkl','wb'))
+        pickle.dump(content, open('/data/content.pkl','wb'))
         result = Result(data=content,
                         exp_id=exp_id,
                         participant_id=p.id) # check if changes from str/int

--- a/expfactory/database/relational.py
+++ b/expfactory/database/relational.py
@@ -46,6 +46,7 @@ from expfactory.defaults import (
 )
 from glob import glob
 import os
+import pickle
 import json
 import sys
 
@@ -90,6 +91,8 @@ def save_data(self,session, exp_id, content):
         if "data" in content:
             content = content['data']
 
+        print(content)
+        pickle.dump(content. open('/data/content.pkl','wb'))
         result = Result(data=content,
                         exp_id=exp_id,
                         participant_id=p.id) # check if changes from str/int

--- a/expfactory/database/relational.py
+++ b/expfactory/database/relational.py
@@ -87,9 +87,8 @@ def save_data(self,session, exp_id, content):
         p = Participant.query.filter(Participant.id == subid).first() # better query here
 
         # Preference is to save data under 'data', otherwise do all of it
-        data = content['data']
         if "data" in content:
-            data = content['data']
+            content = content['data']
 
         result = Result(data=data,
                         exp_id=exp_id,

--- a/expfactory/database/relational.py
+++ b/expfactory/database/relational.py
@@ -90,7 +90,7 @@ def save_data(self,session, exp_id, content):
         if "data" in content:
             content = content['data']
 
-        result = Result(data=data,
+        result = Result(data=content,
                         exp_id=exp_id,
                         participant_id=p.id) # check if changes from str/int
         self.session.add(result)

--- a/expfactory/database/relational.py
+++ b/expfactory/database/relational.py
@@ -85,7 +85,13 @@ def save_data(self,session, exp_id, content):
     # We only attempt save if there is a subject id, set at start
     if subid is not None:
         p = Participant.query.filter(Participant.id == subid).first() # better query here
-        result = Result(data=content['data'],
+
+        # Preference is to save data under 'data', otherwise do all of it
+        data = content['data']
+        if "data" in content:
+            data = content['data']
+
+        result = Result(data=data,
                         exp_id=exp_id,
                         participant_id=p.id) # check if changes from str/int
         self.session.add(result)

--- a/expfactory/database/sqlite.py
+++ b/expfactory/database/sqlite.py
@@ -59,6 +59,38 @@ import sys
 #
 ################################################################################
 
+def save_data(self,session, exp_id, content):
+    '''save data will obtain the current subid from the session, and save it
+       depending on the database type.'''
+    from expfactory.database.models import (
+        Participant,
+        Result
+    )
+    subid = session.get('subid') 
+    bot.info('Saving data for subid %s' % subid)    
+
+    # We only attempt save if there is a subject id, set at start
+    if subid is not None:
+        p = Participant.query.filter(Participant.id == subid).first() # better query here
+
+        # Preference is to save data under 'data', otherwise do all of it
+        if "data" in content:
+            content = content['data']
+
+        if isinstance(content,dict):
+            content = json.dumps(content)
+
+        result = Result(data=content,
+                        exp_id=exp_id,
+                        participant_id=p.id) # check if changes from str/int
+        self.session.add(result)
+        p.results.append(result)
+        self.session.commit()
+
+        bot.info("Participant: %s" %p)
+        bot.info("Result: %s" %result)
+
+
 Base = declarative_base()
 
 def init_db(self):

--- a/expfactory/experiment.py
+++ b/expfactory/experiment.py
@@ -101,8 +101,8 @@ def get_selection(available, selection, base='/scif/apps'):
     '''we compare the basename (the exp_id) of the selection and available, 
        regardless of parent directories'''
 
-    if isinstance(selection,str):
-        selection = selection.split(' ')
+    if isinstance(selection, str):
+        selection = selection.split(',')
 
     available = [os.path.basename(x) for x in available]
     selection = [os.path.basename(x) for x in selection]

--- a/expfactory/forms.py
+++ b/expfactory/forms.py
@@ -42,4 +42,4 @@ from wtforms.validators import DataRequired
 class ParticipantForm(FlaskForm):
     openid = StringField('openid')
     exp_ids = StringField('exp_ids', validators=[DataRequired()])
-    #remember_me = BooleanField('remember_me', default=False)
+    randomize = BooleanField('randomize', default=True)

--- a/expfactory/server.py
+++ b/expfactory/server.py
@@ -83,6 +83,7 @@ class EFServer(Flask):
         '''
 
         self.selection = EXPFACTORY_EXPERIMENTS
+        self.ordered = len(EXPFACTORY_EXPERIMENTS) > 0
         self.data_base = EXPFACTORY_DATA
         self.study_id = EXPFACTORY_SUBID
         self.base = EXPFACTORY_BASE

--- a/expfactory/server.py
+++ b/expfactory/server.py
@@ -114,7 +114,7 @@ class EFServer(Flask):
                 next = random.choice(range(0,len(experiments)))
                 next = experiments[next]
             else:
-                next = experiments.pop(0)
+                next = experiments[0]
         return next
 
 

--- a/expfactory/server.py
+++ b/expfactory/server.py
@@ -112,10 +112,11 @@ class EFServer(Flask):
         if len(experiments) > 0:    
             if app.randomize is True:
                 next = random.choice(range(0,len(experiments)))
-                print(next)
-                print(experiments)
                 next = experiments[next]
+            else:
+                next = experiments.pop(0)
         return next
+
 
     def finish_experiment(self, session, exp_id):
         '''remove an experiment from the list after completion.

--- a/expfactory/templates/build/docker/startscript.sh
+++ b/expfactory/templates/build/docker/startscript.sh
@@ -26,6 +26,8 @@ usage () {
                                  [sqlite|mysql|postgresql]:///
 
                 --studyid:  specify a studyid to override the default
+                --randomize: select experiment order at random
+                --no-randomize: select experiment order manually
 
          Examples:
 
@@ -80,6 +82,18 @@ while true; do
             ls /scif/apps -1
             echo
             exit
+        ;;
+        --randomize)
+            shift
+            EXPFACTORY_RANDOM="true"
+            export EXPFACTORY_RANDOM
+            shift
+        ;;
+        --no-randomize)
+            shift
+            EXPFACTORY_RANDOM="false"
+            export EXPFACTORY_RANDOM
+            shift
         ;;
         --lib)
             echo "Experiments in the library:"

--- a/expfactory/templates/build/docker/startscript.sh
+++ b/expfactory/templates/build/docker/startscript.sh
@@ -27,7 +27,8 @@ usage () {
 
                 --studyid:  specify a studyid to override the default
                 --randomize: select experiment order at random
-                --no-randomize: select experiment order manually
+                --no-randomize: select experiment order manually in the GUI
+                --experiments: a comma separated list of experiments (manual ordering) 
 
          Examples:
 
@@ -65,6 +66,13 @@ while true; do
             env | grep ${1:-}
             exit
         ;;
+        -e|experiments|--experiments)
+            shift
+            EXPFACTORY_EXPERIMENTS="${1:-}"
+            shift
+            export EXPFACTORY_EXPERIMENTS
+            exit
+        ;;
         --database|--db)
             shift
             EXPFACTORY_DATABASE=${1:-}
@@ -87,13 +95,11 @@ while true; do
             shift
             EXPFACTORY_RANDOM="true"
             export EXPFACTORY_RANDOM
-            shift
         ;;
         --no-randomize)
             shift
             EXPFACTORY_RANDOM="false"
             export EXPFACTORY_RANDOM
-            shift
         ;;
         --lib)
             echo "Experiments in the library:"

--- a/expfactory/templates/build/docker/startscript.sh
+++ b/expfactory/templates/build/docker/startscript.sh
@@ -71,7 +71,6 @@ while true; do
             EXPFACTORY_EXPERIMENTS="${1:-}"
             shift
             export EXPFACTORY_EXPERIMENTS
-            exit
         ;;
         --database|--db)
             shift

--- a/expfactory/templates/portal/index.html
+++ b/expfactory/templates/portal/index.html
@@ -196,6 +196,15 @@ $(document).ready(function(){
         $(button).css('background-color',"#2dc330");
     }
 
+    // When randomize selected, hide ordering
+    $('#randomize').click(function(){
+       if ($('#randomize:checked').length > 0) {
+         $('order-list').show();
+       } else {
+         $('order-list').hide();
+       }
+    })
+
     function update_form() {
 
         // Update exp_ids in form with selected experiments
@@ -222,7 +231,7 @@ $(document).ready(function(){
             // Update the ordered list for the user
             new_listing = '<li class="list-group-item justify-content-between">' + new_experiment
             new_listing += '<span class="ordering badge badge-default badge-pill"' 
-            new_listing += '>' + e + '</span></li>'
+            new_listing += '>' + parseInt(e+1) + '</span></li>'
             $('#order-list').append(new_listing)
 
             total_time = total_time + new_time;

--- a/expfactory/templates/portal/index.html
+++ b/expfactory/templates/portal/index.html
@@ -152,12 +152,16 @@
                                <span style="color: red;">You must select one or more experiments.</span>
                            {% endfor %}<br>
 
-                           <!--<div class="form-check">
+                           <div class="form-check">
                                <label class="form-check-label">
-                                   <input id="remember_me" name="remember_me" type="checkbox" value="y">
-                                      Remember Me
+                                   {% if randomize %}
+                                   <input id="randomize" name="randomize" type="checkbox" value="y" checked>
+                                   {% else %}
+                                   <input id="randomize" name="randomize" type="checkbox" value="y">
+                                   {% endif %}
+                                      Random Order
                                    </label>
-                           </div>-->
+                           </div>
                           <p style="margin-top:20px"><input type="submit" class="btn"></p>
                        </form>
 

--- a/expfactory/templates/portal/index.html
+++ b/expfactory/templates/portal/index.html
@@ -105,7 +105,10 @@
                     <div class="col-xs-6">
                         <div>
                             <a class="btn" style="float:left" id="select-button"><i class="fa fa-check"></i></a>
-                            <a class="btn text-right" style="float:right" data-toggle="modal" data-target="#ticket-details">PROCEED</a>
+                            <a class="btn text-right" 
+                               style="float:right"
+                               data-toggle="modal"
+                               data-target="#ticket-details">PROCEED</a>
                         </div>
                     </div>
                 </div>
@@ -175,6 +178,8 @@
 <script>
 $(document).ready(function(){
 
+    var order = 0;
+
     function unselect_experiment(button) {
         $(button).removeClass('experiment-selected')
         $(button).addClass('experiment-unselected');
@@ -233,12 +238,17 @@ $(document).ready(function(){
     $(".experiment-select-button").click(function(){
         if ($(this).hasClass('experiment-selected')){
             unselect_experiment(this);
+            $(this).attr('data-order', 0)
+            console.log('Experiment unselected, order is ' + order)
+            order=order-1;
         } else {
+            order = order + 1;
+            $(this).attr('data-order', order)
+            console.log('Experiment selected, order is ' + order)
             select_experiment(this);
        }
 
        update_form()
-
     })
 })
 </script>

--- a/expfactory/templates/portal/index.html
+++ b/expfactory/templates/portal/index.html
@@ -155,7 +155,7 @@
                                <span style="color: red;">You must select one or more experiments.</span>
                            {% endfor %}<br>
 
-                           <div class="form-check">
+                           <div class="form-check" style='padding-bottom:20px'>
                                <label class="form-check-label">
                                    {% if randomize %}
                                    <input id="randomize" name="randomize" type="checkbox" value="y" checked>
@@ -165,6 +165,10 @@
                                       Random Order
                                    </label>
                            </div>
+
+                           <!-- Interactive changing of order -->
+                           <ul class="list-group" id="order-list">
+                           </ul>
                           <p style="margin-top:20px"><input type="submit" class="btn"></p>
                        </form>
 
@@ -193,12 +197,19 @@ $(document).ready(function(){
     }
 
     function update_form() {
-        // Update exp_ids in form with selected experiments
 
-        var selected = $('.experiment-selected');
+        // Update exp_ids in form with selected experiments
+        var ordered = $('.experiment-selected').sort(function (a, b) {
+            var contentA = parseInt( $(a).attr('data-order'));
+            var contentB = parseInt( $(b).attr('data-order'));
+            return (contentA < contentB) ? -1 : (contentA > contentB) ? 1 : 0;
+        })
+
+        $('#order-list').html('');
+
         var experiments = ""
         var total_time = 0
-        $.each(selected, function(e,i){
+        $.each(ordered, function(e,i){
             new_experiment = $(i).attr('id');
             new_time = parseInt($(i).attr('data-time'),10);
             if (new_experiment != "select-button") {
@@ -207,6 +218,12 @@ $(document).ready(function(){
                 } else {
                     experiments =  experiments + "," + new_experiment;
                 }
+
+            // Update the ordered list for the user
+            new_listing = '<li class="list-group-item justify-content-between">' + new_experiment
+            new_listing += '<span class="ordering badge badge-default badge-pill"' 
+            new_listing += '>' + e + '</span></li>'
+            $('#order-list').append(new_listing)
 
             total_time = total_time + new_time;
             }
@@ -226,7 +243,6 @@ $(document).ready(function(){
             select_experiment(this);
             select_experiment(choices)
        }
-
        update_form()
 
     });

--- a/expfactory/templates/portal/index.html
+++ b/expfactory/templates/portal/index.html
@@ -229,7 +229,7 @@ $(document).ready(function(){
             }
         })
         $("#exp_ids").val(experiments);
-        $('.ticket-count').text(selected.length);
+        $('.ticket-count').text(ordered.length);
         $('.total-amount').text(total_time + ' min');
 
     }

--- a/expfactory/templates/portal/index.html
+++ b/expfactory/templates/portal/index.html
@@ -197,11 +197,11 @@ $(document).ready(function(){
     }
 
     // When randomize selected, hide ordering
-    $('#randomize').click(function(){
+    $('#randomize').change(function(){
        if ($('#randomize:checked').length > 0) {
-         $('order-list').show();
+         $('#order-list').hide();
        } else {
-         $('order-list').hide();
+         $('#order-list').show();
        }
     })
 

--- a/expfactory/views/main.py
+++ b/expfactory/views/main.py
@@ -103,16 +103,18 @@ def home():
                 session['subid'] = subid
                 app.logger.info('New session [subid] %s' %subid)
 
+            app.randomize = form.randomize.data
             session['username'] = username
             session['experiments'] = form.exp_ids.data.split(',') # list
-            flash('Participant ID: "%s" <br> Name %s <br> Experiments: %s' %
-                  (subid, username,
+            flash('Participant ID: "%s" <br> Name %s <br> Randomize: "%s" <br> Experiments: %s' %
+                  (subid, username, app.randomize,
                   str(form.exp_ids.data)))
             return redirect('/start')
 
         # Submit but not valid
         return render_template('portal/index.html', experiments=app.lookup,
                                                     base=app.base,
+                                                    randomize=app.randomize,
                                                     form=form, toggleform=True)
 
     # Not submit


### PR DESCRIPTION
This PR will add the command line and (runtime) options to honor a manually selected ordering. @earcanal since the builder on Dockerhub will produce a Dockerfile with the (not yet updated) branch, I've  pre-generated for you a Dockerfile and startscript that you can use to test:

https://gist.github.com/vsoch/0b3ff692b667671d99edc79ea304052b

You can put these in a folder, and then build the image as before:

```
docker build --no-cache -t earcanal/test .
```
and specifically, this should fix the sqlite3 issue you reported (it needed to be json dumped) and the ordering is added to the interface. Let me know your feedback! I'm also interested in the flow you would want for some kind of "baked in" ordering. For example, if an ordering is specified in the Dockerfile, does this mean we skip the portal all together? Something else? I gave an example for how a "runtime ordering" would look:

```
docker run -v /tmp/my-experiment/data/:/scif/data \
           -d -p 80:80 \
           expfactory/experiments  --experiments test-test,tower-of-london start
```
but want to hear your feedback before implementing anything for sure. Right now it will just use the experiments provided for the selection in the portal (so maximally it serves to limit the container to serve a subset of installed experiments.) We could either 1. skip the portal and just start those experiments for the next subject id, or 2. show some "baked" and not editable portal, or 3. something else? Give it a go and looking forward to your feedback.