### PR TITLE
Fix reverse proxy

### DIFF
--- a/examples/docker/custom-container/Dockerfile
+++ b/examples/docker/custom-container/Dockerfile
@@ -28,7 +28,7 @@ RUN cp expfactory/config_dummy.py expfactory/config.py && \
     chmod u+x /opt/expfactory/script/generate_key.sh && \
     /bin/bash /opt/expfactory/script/generate_key.sh /opt/expfactory/expfactory/config.py
 RUN python3 setup.py install
-RUN python3 -m pip install pyaml    pymysql psycopg2
+RUN python3 -m pip install pyaml pymysql psycopg2 beautifulsoup4
 RUN apt-get clean          # tests, mysql,  postgres
 
 ########################################

--- a/expfactory/server.py
+++ b/expfactory/server.py
@@ -170,19 +170,26 @@ class ReverseProxied(object):
             if path_info.startswith(script_name):
                 environ['PATH_INFO'] = path_info[len(script_name):]
 
-        scheme = environ.get('HTTP_X_SCHEME', '')
-        if scheme:
-            environ['wsgi.url_scheme'] = scheme
+        # scheme = environ.get('HTTP_X_SCHEME', '')
+        # if scheme:
+        #     environ['wsgi.url_scheme'] = scheme
 
-        server = environ.get('HTTP_X_FORWARDED_SERVER', '')
-        if server:
-            environ['HTTP_HOST'] = server
+        # server = environ.get('HTTP_X_FORWARDED_SERVER', '')
+        # if server:
+        #     environ['HTTP_HOST'] = server
 
         return self.app(environ, start_response)
 
+
+# Import the fixer
+from werkzeug.contrib.fixers import ProxyFix
+
 app = EFServer(__name__)
 app.config.from_object('expfactory.config')
+# Use the fixer
+app.wsgi_app = ProxyFix(app.wsgi_app, 2)
 app.wsgi_app = ReverseProxied(app.wsgi_app)
+
 
 # EXPERIMENTS #################################################################
 

--- a/expfactory/server.py
+++ b/expfactory/server.py
@@ -142,8 +142,47 @@ EFServer.print_user = print_user
 EFServer.finish_user = finish_user
 EFServer.restart_user = restart_user
 
+class ReverseProxied(object):
+    '''Wrap the application in this middleware and configure the
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+    location /myprefix {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /myprefix;
+        }
+
+    :param app: the WSGI application
+    '''
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+
+        scheme = environ.get('HTTP_X_SCHEME', '')
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+
+        server = environ.get('HTTP_X_FORWARDED_SERVER', '')
+        if server:
+            environ['HTTP_HOST'] = server
+
+        return self.app(environ, start_response)
+
 app = EFServer(__name__)
 app.config.from_object('expfactory.config')
+app.wsgi_app = ReverseProxied(app.wsgi_app)
 
 # EXPERIMENTS #################################################################
 

--- a/expfactory/templates/build/docker/Dockerfile.dev
+++ b/expfactory/templates/build/docker/Dockerfile.dev
@@ -29,7 +29,7 @@ RUN cp expfactory/config_dummy.py expfactory/config.py && \
     chmod u+x /opt/expfactory/script/generate_key.sh && \
     /bin/bash /opt/expfactory/script/generate_key.sh /opt/expfactory/expfactory/config.py
 RUN python3 setup.py install
-RUN python3 -m pip install pyaml    pymysql psycopg2
+RUN python3 -m pip install pyaml pymysql psycopg2 beautifulsoup4
 RUN apt-get clean          # tests, mysql,  postgres
 
 ########################################

--- a/expfactory/templates/build/docker/Dockerfile.template
+++ b/expfactory/templates/build/docker/Dockerfile.template
@@ -28,7 +28,7 @@ RUN cp expfactory/config_dummy.py expfactory/config.py && \
     chmod u+x /opt/expfactory/script/generate_key.sh && \
     /bin/bash /opt/expfactory/script/generate_key.sh /opt/expfactory/expfactory/config.py
 RUN python3 setup.py install
-RUN python3 -m pip install pyaml    pymysql psycopg2
+RUN python3 -m pip install pyaml pymysql psycopg2 beautifulsoup4
 RUN apt-get clean          # tests, mysql,  postgres
 
 ########################################

--- a/expfactory/templates/experiments/experiment.html
+++ b/expfactory/templates/experiments/experiment.html
@@ -1,13 +1,1 @@
 {% include experiment %}
-
-<script type="text/javascript">
-    var csrf_token = "{{ csrf_token() }}";
-
-    $.ajaxSetup({
-        beforeSend: function(xhr, settings) {
-            if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-                xhr.setRequestHeader("X-CSRFToken", csrf_token);
-            }
-        }
-    });
-</script>

--- a/expfactory/templates/routes/start.html
+++ b/expfactory/templates/routes/start.html
@@ -23,12 +23,12 @@
                          <h2>Welcome {{ session['username'] }}!</h2>
                          {% include "routes/start_message.html" %}
                          <br><br>
-                         <a href="/finish"><button id="disagree_button" 
+                         <a href="finish"><button id="disagree_button"
                                                    type="button" 
                                                    class="btn btn-default">Disagree</button></a>
                         </div>
                         <div class="modal-footer">
-                             <a href="/next"><button type="button" 
+                             <a href="next"><button type="button"
                                 id="next_button" 
                                 class="btn btn-default js-btn-step" 
                                 data-orientation="next">Start</button></a>

--- a/expfactory/views/general.py
+++ b/expfactory/views/general.py
@@ -36,6 +36,7 @@ from flask import (
     render_template, 
     request, 
     redirect,
+    url_for,
     session
 )
 
@@ -76,7 +77,7 @@ def portal():
             flash('Participant ID: "%s" <br> Name %s <br> Randomize: "%s" <br> Experiments: %s' %
                   (subid, username, app.randomize,
                   str(form.exp_ids.data)))
-            return redirect('/start')
+            return redirect(url_for('start'))
 
         # Submit but not valid
         return render_template('portal/index.html', experiments=app.lookup,

--- a/expfactory/views/headless.py
+++ b/expfactory/views/headless.py
@@ -37,6 +37,7 @@ from flask import (
     render_template, 
     request, 
     redirect,
+    url_for,
     session
 )
 
@@ -70,7 +71,7 @@ def login():
     # If not headless, we don't need to login
     if not app.headless:
         app.logger.debug('Not running in headless mode, redirect to /start.')
-        redirect('/start')
+        redirect(url_for('start'))
 
     subid = session.get('subid')
     if not subid:
@@ -85,7 +86,7 @@ def login():
             session['token'] = token
 
             app.logger.info('Logged in user [subid] %s' %subid)
-    return redirect('/next')
+    return redirect(url_for('next'))
 
 
 # Denied Entry for Headless

--- a/expfactory/views/main.py
+++ b/expfactory/views/main.py
@@ -37,6 +37,7 @@ from flask import (
     render_template, 
     request, 
     redirect,
+    url_for,
     session
 )
 
@@ -97,7 +98,7 @@ def home():
             form = EntryForm()
             session['experiments'] = [os.path.basename(x) for x in app.experiments] # list
             return render_template('routes/entry.html', form=form)
-        return redirect('/next')
+        return redirect(url_for('next'))
 
     return portal()
 
@@ -138,10 +139,10 @@ def next():
  
     if experiment is not None:
         app.logger.debug('Next experiment is %s' % experiment)
-        return perform_checks('/experiments/%s' % experiment, do_redirect=True,
+        return perform_checks('experiments/%s' % experiment, do_redirect=True,
                               next=experiment)
 
-    return redirect('/finish')
+    return redirect(url_for('finish'))
    
 
 # Reset/Logout
@@ -150,7 +151,7 @@ def logout():
 
     # If the user has finished, clear session
     clear_session()
-    return redirect('/')
+    return redirect(url_for('home'))
 
 
 # Finish
@@ -167,7 +168,7 @@ def finish():
         app.finish_user(subid)
         clear_session()
         return render_template('routes/finish.html')
-    return redirect('/')
+    return redirect(url_for('home'))
 
 
 @app.route('/start')

--- a/expfactory/views/main.py
+++ b/expfactory/views/main.py
@@ -122,9 +122,8 @@ def save():
         app.logger.info('Finished %s, %s remaining.' % (exp_id, len(experiments)))
 
         # Note, this doesn't seem to be enough to trigger ajax success
-        return json.dumps({'success':True}), 200, {'ContentType':'application/json'} 
-    return json.dumps({'success':False}), 403, {'ContentType':'application/json'} 
-
+        return jsonify(success=True)
+    return jsonify(success=False)
 
 
 @app.route('/next', methods=['POST', 'GET'])

--- a/expfactory/views/utils.py
+++ b/expfactory/views/utils.py
@@ -35,6 +35,7 @@ from flask import (
     flash,
     render_template, 
     redirect,
+    url_for,
     session
 )
 
@@ -60,7 +61,7 @@ def perform_checks(template, do_redirect=False, context=None, next=None, quiet=F
     # Headless mode requires token
     if "token" not in session and app.headless is True:
         flash('A token is required for these experiments.')
-        return redirect('/')
+        return redirect(url_for('home'))
 
     # Update the user / log
     if quiet is False:
@@ -68,15 +69,15 @@ def perform_checks(template, do_redirect=False, context=None, next=None, quiet=F
 
     if username is None and app.headless is False:
         flash('You must start a session before doing experiments.')
-        return redirect('/')
+        return redirect(url_for('home'))
 
     if subid is None:
         flash('You must have a participant identifier before doing experiments')
-        return redirect('/')
+        return redirect(url_for('home'))
 
     if next is None:
         flash('Congratulations, you have finished the battery!')
-        return redirect('/finish')
+        return redirect(url_for('finish'))
 
     if do_redirect is True:
         app.logger.debug('Redirecting to %s' %template)


### PR DESCRIPTION
At my institution I can only deploy behind an Apache reverse proxy with a non-root URL.

e.g. http://example.com/my-experiment

The only way I could figure out how to deploy experiment factory in this context was to include the [ReverseProxied middleware](http://flask.pocoo.org/snippets/35/) and change all `redirect()` calls to use `url_for()` in place of the absolute urls.

This may or may not be generally useful. It doesn't appear to break existing root deployment, but deploying in a non-root context requires modifying nginx.gunicorn.conf as documented in flask snippet 35.