### PR TITLE
Fix jinja2 and wekzerg version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Critical items to know are:
 
 
 ## [v3.x](https://github.com/expfactory/expfactory/tree/master) (master)
+ - pinning version of werkzeug (3.17)
  - adding black lint formatting (3.16)
  - pinning flask version to known working (3.15)
  - set psycopg2==2.7.5, removing python 2 support (3.14)

--- a/expfactory/version.py
+++ b/expfactory/version.py
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 
-__version__ = "3.16"
+__version__ = "3.17"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "expfactory"
@@ -40,19 +40,29 @@ DESCRIPTION = "software to generate a reproducible container battery of experime
 LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
-    ("flask", {"exact_version": "1.0.2"}),
+    ("Flask", {"exact_version": "0.12.2"}),
     ("flask-restful", {"min_version": "0.3.6"}),
     ("flask-blueprint", {"exact_version": "1.2.2"}),
-    ("Flask-WTF", {"min_version": "0.14.2"}),
-    ("Flask-SQLAlchemy", {"min_version": "2.3.2"}),
-    ("flask-cors", {"min_version": "3.0.6"}),
+    ("Flask-WTF", {"exact_version": "0.14.2"}),
+    ("Flask-SQLAlchemy", {"exact_version": "2.3.2"}),
+    ("Flask-cors", {"exact_version": "3.0.6"}),
     ("requests", {"min_version": "2.12.4"}),
     ("retrying", {"min_version": "1.3.3"}),
+    ("werkzeug", {"exact_version": "0.12.2"}),
 )
 
 # Original working versions, in case needed
 # flask 1.0.2
 # Flask-Cors==3.0.6
+# Flask-RESTful==0.3.6
+# Flask-SQLAlchemy==2.3.2
+# Flask-WTF==0.14.2
+# flask-blueprint==1.2.2
+
+# Working verisons in expfactory-experiments container
+# Flask==0.12.2
+# flask-blueprint==1.2.2
+# Flask-Cors==3.0.3
 # Flask-RESTful==0.3.6
 # Flask-SQLAlchemy==2.3.2
 # Flask-WTF==0.14.2

--- a/expfactory/version.py
+++ b/expfactory/version.py
@@ -46,6 +46,7 @@ INSTALL_REQUIRES = (
     ("Flask-WTF", {"exact_version": "0.14.2"}),
     ("Flask-SQLAlchemy", {"exact_version": "2.3.2"}),
     ("Flask-cors", {"exact_version": "3.0.6"}),
+    ("Jinja2", {"exact_version": "2.10"}),
     ("requests", {"min_version": "2.12.4"}),
     ("retrying", {"min_version": "1.3.3"}),
     ("werkzeug", {"exact_version": "0.12.2"}),
@@ -61,6 +62,7 @@ INSTALL_REQUIRES = (
 
 # Working verisons in expfactory-experiments container
 # Flask==0.12.2
+# Jinja2==2.1
 # flask-blueprint==1.2.2
 # Flask-Cors==3.0.3
 # Flask-RESTful==0.3.6


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Jinja2 seems to just have released a version 3.x beta, and it appears that it requires a higher version of Python (invalid syntax formatting) as the library is not even able to import (see #125). This pull request will pin versions to previous working - which should be reasonable since expfactory is entirely working from within the container and the user won't need to install alongside host conda, etc.

**This fixes or addresses the following GitHub issues:**

- Ref: #125 

Attn: @expfactory-admin
