### PR TITLE
install with pip instead

### DIFF
--- a/expfactory/templates/build/docker/Dockerfile.dev
+++ b/expfactory/templates/build/docker/Dockerfile.dev
@@ -28,7 +28,7 @@ RUN python3 -m pip install gunicorn
 RUN cp expfactory/config_dummy.py expfactory/config.py && \
     chmod u+x /opt/expfactory/script/generate_key.sh && \
     /bin/bash /opt/expfactory/script/generate_key.sh /opt/expfactory/expfactory/config.py
-RUN python3 setup.py install
+RUN python3 -m pip install .
 RUN python3 -m pip install pyaml    pymysql psycopg2==2.7.5
 RUN apt-get clean          # tests, mysql,  postgres
 

--- a/expfactory/templates/build/docker/Dockerfile.https
+++ b/expfactory/templates/build/docker/Dockerfile.https
@@ -27,7 +27,7 @@ RUN python3 -m pip install gunicorn
 RUN cp expfactory/config_dummy.py expfactory/config.py && \
     chmod u+x /opt/expfactory/script/generate_key.sh && \
     /bin/bash /opt/expfactory/script/generate_key.sh /opt/expfactory/expfactory/config.py
-RUN python3 setup.py install
+RUN python3 -m pip install .
 RUN python3 -m pip install pyaml    pymysql psycopg2==2.7.5
 RUN apt-get clean          # tests, mysql,  postgres
 

--- a/expfactory/templates/build/docker/Dockerfile.template
+++ b/expfactory/templates/build/docker/Dockerfile.template
@@ -27,7 +27,7 @@ RUN python3 -m pip install gunicorn
 RUN cp expfactory/config_dummy.py expfactory/config.py && \
     chmod u+x /opt/expfactory/script/generate_key.sh && \
     /bin/bash /opt/expfactory/script/generate_key.sh /opt/expfactory/expfactory/config.py
-RUN python3 setup.py install
+RUN python3 -m pip install .
 RUN python3 -m pip install pyaml    pymysql psycopg2==2.7.5
 RUN apt-get clean          # tests, mysql,  postgres
 

--- a/expfactory/templates/build/docker/builder-ci/Dockerfile
+++ b/expfactory/templates/build/docker/builder-ci/Dockerfile
@@ -9,7 +9,7 @@ FROM quay.io/vanessa/expfactory-builder:base
 WORKDIR /opt
 ADD . /opt
 WORKDIR /opt/expfactory
-RUN python3 setup.py install
+RUN python3 -m pip install .
 RUN mv /opt/entrypoint.sh /entrypoint.sh
 RUN chmod u+x /entrypoint.sh
 RUN mkdir -p /scif/apps

--- a/expfactory/templates/build/docker/builder-dev/Dockerfile
+++ b/expfactory/templates/build/docker/builder-dev/Dockerfile
@@ -9,7 +9,7 @@ FROM quay.io/vanessa/expfactory-builder:base
 WORKDIR /opt
 RUN git clone -b add/variables https://www.github.com/expfactory/expfactory
 WORKDIR /opt/expfactory
-RUN python3 setup.py install
+RUN python3 -m pip install .
 RUN python3 -m pip install pyaml
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod u+x /entrypoint.sh

--- a/expfactory/templates/build/docker/builder/Dockerfile
+++ b/expfactory/templates/build/docker/builder/Dockerfile
@@ -9,7 +9,7 @@ FROM quay.io/vanessa/expfactory-builder:base
 WORKDIR /opt
 RUN git clone https://www.github.com/expfactory/expfactory
 WORKDIR /opt/expfactory
-RUN python3 setup.py install
+RUN python3 -m pip install .
 RUN python3 -m pip install pyaml
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod u+x /entrypoint.sh

--- a/expfactory/version.py
+++ b/expfactory/version.py
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 
-__version__ = "3.17"
+__version__ = "3.18"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "expfactory"
@@ -40,6 +40,7 @@ DESCRIPTION = "software to generate a reproducible container battery of experime
 LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
+    ("itsdangerous", {"min_version": "0.24"}),
     ("flask", {"exact_version": "1.0.2"}),
     ("flask-restful", {"min_version": "0.3.6"}),
     ("flask-blueprint", {"exact_version": "1.2.2"}),


### PR DESCRIPTION
Signed-off-by: vsoch <vsochat@stanford.edu>

This is a test to see if installing with pip removes some of the warnings created by setuptools, seen in https://github.com/expfactory-experiments/breath-counting-task/pull/13.