### PR TITLE
Adding support for time limit from environment

### DIFF
--- a/expfactory/experiment.py
+++ b/expfactory/experiment.py
@@ -143,7 +143,7 @@ def validate(folder=None, cleanup=False):
 
 
 def get_library(lookup=True, key="exp_id"):
-    """ return the raw library, without parsing"""
+    """return the raw library, without parsing"""
     library = None
     response = requests.get(EXPFACTORY_LIBRARY)
     if response.status_code == 200:

--- a/expfactory/server.py
+++ b/expfactory/server.py
@@ -159,7 +159,16 @@ cors = CORS(
 app.config["CORS_HEADERS"] = "Content-Type"
 
 # 3 hours. Set to None for life of session
-app.config["WTF_CSRF_TIME_LIMIT"] = 10800
+time_limit = os.environ.get("EXPFACTORY_WTF_CSRF_TIME_LIMIT")
+if time_limit:
+    try:
+        time_limit = int(time_limit)
+    except:
+        bot.warning(
+            "time_limit setting %s cannot be parsed, will use default" % time_limit
+        )
+
+app.config["WTF_CSRF_TIME_LIMIT"] = time_limit or 10800
 
 csrf = CSRFProtect(app)
 

--- a/script/generate_key.py
+++ b/script/generate_key.py
@@ -3,8 +3,8 @@
 import random
 import string
 
-punctuation = '!#$%&()*+,-./:;<=>?@^_{|}~'
+punctuation = "!#$%&()*+,-./:;<=>?@^_{|}~"
 choices = string.ascii_letters + string.digits + punctuation
 selected = [random.SystemRandom().choice(choices) for _ in range(50)]
-generated_key = ''.join(selected)
+generated_key = "".join(selected)
 print(generated_key)

--- a/setup.py
+++ b/setup.py
@@ -6,56 +6,57 @@ import os
 # HELPER FUNCTIONS #############################################################
 ################################################################################
 
+
 def get_lookup():
-    '''get version by way of expfactory.version, returns a 
+    """get version by way of expfactory.version, returns a
     lookup dictionary with several global variables without
     needing to import expfactory
-    '''
+    """
     lookup = dict()
-    version_file = os.path.join('expfactory', 'version.py')
+    version_file = os.path.join("expfactory", "version.py")
     with open(version_file) as filey:
         exec(filey.read(), lookup)
     return lookup
 
+
 # Read in requirements
 def get_requirements(lookup=None):
-    '''get_requirements reads in requirements and versions from
-    the lookup obtained with get_lookup'''
+    """get_requirements reads in requirements and versions from
+    the lookup obtained with get_lookup"""
 
     if lookup == None:
         lookup = get_lookup()
 
     install_requires = []
-    for module in lookup['INSTALL_REQUIRES']:
+    for module in lookup["INSTALL_REQUIRES"]:
         module_name = module[0]
         module_meta = module[1]
         if "exact_version" in module_meta:
-            dependency = "%s==%s" %(module_name, module_meta['exact_version'])
+            dependency = "%s==%s" % (module_name, module_meta["exact_version"])
         elif "min_version" in module_meta:
-            if module_meta['min_version'] == None:
+            if module_meta["min_version"] == None:
                 dependency = module_name
             else:
-                dependency = "%s>=%s" %(module_name, module_meta['min_version'])
+                dependency = "%s>=%s" % (module_name, module_meta["min_version"])
         install_requires.append(dependency)
     return install_requires
 
 
-
 # Make sure everything is relative to setup.py
-install_path = os.path.dirname(os.path.abspath(__file__)) 
+install_path = os.path.dirname(os.path.abspath(__file__))
 os.chdir(install_path)
 
 # Get version information from the lookup
 lookup = get_lookup()
-VERSION = lookup['__version__']
-NAME = lookup['NAME']
-AUTHOR = lookup['AUTHOR']
-AUTHOR_EMAIL = lookup['AUTHOR_EMAIL']
-PACKAGE_URL = lookup['PACKAGE_URL']
-KEYWORDS = lookup['KEYWORDS']
-DESCRIPTION = lookup['DESCRIPTION']
-LICENSE = lookup['LICENSE']
-with open('README.md') as filey:
+VERSION = lookup["__version__"]
+NAME = lookup["NAME"]
+AUTHOR = lookup["AUTHOR"]
+AUTHOR_EMAIL = lookup["AUTHOR_EMAIL"]
+PACKAGE_URL = lookup["PACKAGE_URL"]
+KEYWORDS = lookup["KEYWORDS"]
+DESCRIPTION = lookup["DESCRIPTION"]
+LICENSE = lookup["LICENSE"]
+with open("README.md") as filey:
     LONG_DESCRIPTION = filey.read()
 
 ################################################################################
@@ -67,31 +68,33 @@ if __name__ == "__main__":
 
     INSTALL_REQUIRES = get_requirements(lookup)
 
-    setup(name=NAME,
-          version=VERSION,
-          author=AUTHOR,
-          author_email=AUTHOR_EMAIL,
-          maintainer=AUTHOR,
-          maintainer_email=AUTHOR_EMAIL,
-          packages=find_packages(), 
-          include_package_data=True,
-          zip_safe=False,
-          url=PACKAGE_URL,
-          license=LICENSE,
-          description=DESCRIPTION,
-          long_description=LONG_DESCRIPTION,
-          long_description_content_type="text/markdown",
-          keywords=KEYWORDS,
-          install_requires = INSTALL_REQUIRES,
-          classifiers=[
-              'Intended Audience :: Science/Research',
-              'Intended Audience :: Developers',
-              'License :: OSI Approved :: MIT License',
-              'Programming Language :: C',
-              'Programming Language :: Python',
-              'Topic :: Software Development',
-              'Topic :: Scientific/Engineering',
-              'Operating System :: Unix',
-              'Programming Language :: Python :: 3',
-          ],
-          entry_points = {'console_scripts': ['expfactory=expfactory.cli:main']})
+    setup(
+        name=NAME,
+        version=VERSION,
+        author=AUTHOR,
+        author_email=AUTHOR_EMAIL,
+        maintainer=AUTHOR,
+        maintainer_email=AUTHOR_EMAIL,
+        packages=find_packages(),
+        include_package_data=True,
+        zip_safe=False,
+        url=PACKAGE_URL,
+        license=LICENSE,
+        description=DESCRIPTION,
+        long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
+        keywords=KEYWORDS,
+        install_requires=INSTALL_REQUIRES,
+        classifiers=[
+            "Intended Audience :: Science/Research",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: C",
+            "Programming Language :: Python",
+            "Topic :: Software Development",
+            "Topic :: Scientific/Engineering",
+            "Operating System :: Unix",
+            "Programming Language :: Python :: 3",
+        ],
+        entry_points={"console_scripts": ["expfactory=expfactory.cli:main"]},
+    )


### PR DESCRIPTION
The user can set EXPFACTORY_WTF_CSRF_TIME_LIMIT in the Dockerfile to control it

The same instructions for testing can be used as mentioned in: https://github.com/expfactory/expfactory/pull/139#issue-1006905274. But the branch name to clone is add/envar-for-time-limit and not the one mentioned there!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

- Ref: #140 
