### PR TITLE
Adding support for custom tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Critical items to know are:
 
 
 ## [v3.x](https://github.com/expfactory/expfactory/tree/master) (master)
+ - ability to generate users from newline separated file with --tokens (3.2.13)
  - updating flask to 1.1.4 (3.2.12)
  - updating yaml to use safe_load (3.2.11)
  - adding support for receiving a token in the url and updating docs template (3.2.0)

--- a/expfactory/cli/__init__.py
+++ b/expfactory/cli/__init__.py
@@ -73,6 +73,12 @@ def get_parser():
     )
 
     users.add_argument(
+        "--tokens",
+        dest="token_file",
+        help="provide a filename with a single list (newline separated) of custom tokens to generate",
+    )
+
+    users.add_argument(
         "--list",
         dest="list",
         help="list current tokens, for a headless install",

--- a/expfactory/cli/users.py
+++ b/expfactory/cli/users.py
@@ -56,6 +56,13 @@ def main(args, parser, subparser):
             app.print_user(user)
         sys.exit(0)
 
+    # The user wants to create custom tokens
+    token_file = args.token_file
+    if token_file is not None:
+        users = app.tokens_from_file(token_file)
+        print("%s users existing or generated from file." % len(users))
+        sys.exit(0)
+
     # The user wants to manage user token
     action = None
     if args.revoke is not None:

--- a/expfactory/database/filesystem.py
+++ b/expfactory/database/filesystem.py
@@ -202,14 +202,16 @@ def tokens_from_file(self, token_file):
             % token_file
         )
     users = []
-    for token in read_file(token_file):
+    for token in read_file(token_file, readlines=True):
         token = token.strip()
 
         # Skip comments
-        if token.startswith("#"):
+        if token.startswith("#") or not token:
             continue
         if not re.search(token_regex, token):
-            self.logger.warning("Token %s does not match regex requirements, skipping" % token)
+            self.logger.warning(
+                "Token %s does not match regex requirements, skipping" % token
+            )
 
         users.append(self.generate_user(token))
     return users

--- a/expfactory/database/relational.py
+++ b/expfactory/database/relational.py
@@ -146,6 +146,7 @@ def restart_user(self, subid):
 
 # Tokens #######################################################################
 
+
 def tokens_from_file(self, token_file):
     """
     Generate one or more tokens from a newline separated file.
@@ -158,21 +159,25 @@ def tokens_from_file(self, token_file):
             % token_file
         )
     users = []
-    for token in read_file(token_file):
+    for token in read_file(token_file, readlines=True):
+
         token = token.strip()
 
         # Skip comments
-        if token.startswith("#"):
+        if token.startswith("#") or not token:
             continue
 
         if not re.search(token_regex, token):
-            self.logger.warning("Token %s does not match regex requirements, skipping" % token)
+            self.logger.warning(
+                "Token %s does not match regex requirements, skipping" % token
+            )
 
         # Only create if not created yet
         p = Participant.query.filter(Participant.token == token).first()
         if p is None:
             users.append(self.generate_subid(token))
     return users
+
 
 def validate_token(self, token):
     """

--- a/expfactory/database/relational.py
+++ b/expfactory/database/relational.py
@@ -36,7 +36,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 
 from sqlalchemy.ext.declarative import declarative_base
 from expfactory.logger import bot
-from expfactory.utils import write_json
+from expfactory.utils import write_json, read_file, token_regex
 from expfactory.defaults import EXPFACTORY_SUBID, EXPFACTORY_DATA
 from glob import glob
 import os
@@ -58,15 +58,18 @@ import sys
 
 
 def generate_subid(self, token=None, return_user=False):
-    """generate a new user in the database, still session based so we
+    """
+    Generate a new user in the database, still session based so we
     create a new identifier.
     """
     from expfactory.database.models import Participant
 
+    # TODO: do we need to query here first instead to see if exists?
     if not token:
         p = Participant()
     else:
         p = Participant(token=token)
+
     self.session.add(p)
     self.session.commit()
     if return_user is True:
@@ -75,7 +78,9 @@ def generate_subid(self, token=None, return_user=False):
 
 
 def print_user(self, user):
-    """print a relational database user"""
+    """
+    Print a relational database user
+    """
     status = "active"
     token = user.token
 
@@ -91,7 +96,8 @@ def print_user(self, user):
 
 
 def list_users(self, user=None):
-    """list users, each having a model in the database. A headless experiment
+    """
+    List users, each having a model in the database. A headless experiment
     will use protected tokens, and interactive will be based on auto-
     incremented ids.
     """
@@ -108,7 +114,8 @@ def list_users(self, user=None):
 
 
 def generate_user(self):
-    """generate a new user in the database, still session based so we
+    """
+    Generate a new user in the database, still session based so we
     create a new identifier. This function is called from the users new
     entrypoint, and it assumes we want a user generated with a token.
     """
@@ -117,8 +124,10 @@ def generate_user(self):
 
 
 def finish_user(self, subid):
-    """finish user will remove a user's token, making the user entry not
-    accesible if running in headless model"""
+    """
+    Finish user will remove a user's token, making the user entry not
+    accesible if running in headless model
+    """
 
     p = self.revoke_token(subid)
     p.token = "finished"
@@ -127,7 +136,9 @@ def finish_user(self, subid):
 
 
 def restart_user(self, subid):
-    """restart a user, which means revoking and issuing a new token."""
+    """
+    Restart a user, which means revoking and issuing a new token.
+    """
     p = self.revoke_token(subid)
     p = self.refresh_token(subid)
     return p
@@ -135,9 +146,37 @@ def restart_user(self, subid):
 
 # Tokens #######################################################################
 
+def tokens_from_file(self, token_file):
+    """
+    Generate one or more tokens from a newline separated file.
+    """
+    from expfactory.database.models import Participant
+
+    if not os.path.exists(token_file):
+        sys.exit(
+            "Tokens file %s does not exist. Are you sure it's bound to the container?"
+            % token_file
+        )
+    users = []
+    for token in read_file(token_file):
+        token = token.strip()
+
+        # Skip comments
+        if token.startswith("#"):
+            continue
+
+        if not re.search(token_regex, token):
+            self.logger.warning("Token %s does not match regex requirements, skipping" % token)
+
+        # Only create if not created yet
+        p = Participant.query.filter(Participant.token == token).first()
+        if p is None:
+            users.append(self.generate_subid(token))
+    return users
 
 def validate_token(self, token):
-    """retrieve a subject based on a token. Valid means we return a participant
+    """
+    Retrieve a subject based on a token. Valid means we return a participant
     invalid means we return None
     """
     from expfactory.database.models import Participant
@@ -152,8 +191,10 @@ def validate_token(self, token):
 
 
 def revoke_token(self, subid):
-    """revoke a token by removing it. Is done at finish, and also available
-    as a command line option"""
+    """
+    Revoke a token by removing it. Is done at finish, and also available
+    as a command line option
+    """
     from expfactory.database.models import Participant
 
     p = Participant.query.filter(Participant.id == subid).first()
@@ -164,7 +205,9 @@ def revoke_token(self, subid):
 
 
 def refresh_token(self, subid):
-    """refresh or generate a new token for a user"""
+    """
+    Refresh or generate a new token for a user
+    """
     from expfactory.database.models import Participant
 
     p = Participant.query.filter(Participant.id == subid).first()
@@ -175,8 +218,10 @@ def refresh_token(self, subid):
 
 
 def save_data(self, session, exp_id, content):
-    """save data will obtain the current subid from the session, and save it
-    depending on the database type. Currently we just support flat files"""
+    """
+    Save data will obtain the current subid from the session, and save it
+    depending on the database type. Currently we just support flat files
+    """
     from expfactory.database.models import Participant, Result
 
     subid = session.get("subid")
@@ -222,7 +267,8 @@ Base = declarative_base()
 
 
 def init_db(self):
-    """initialize the database, with the default database path or custom with
+    """
+    Initialize the database, with the default database path or custom with
     a format corresponding to the database type:
 
     Examples:

--- a/expfactory/database/sqlite.py
+++ b/expfactory/database/sqlite.py
@@ -90,9 +90,9 @@ Base = declarative_base()
 
 
 def init_db(self):
-    """initialize the database, with the default database path or custom of
+    """
+    Initialize the database, with the default database path or custom of
     the format sqlite:////scif/data/expfactory.db
-
     """
 
     # Database Setup, use default if uri not provided

--- a/expfactory/server.py
+++ b/expfactory/server.py
@@ -131,6 +131,7 @@ EFServer.generate_user = generate_user
 EFServer.validate_token = validate_token
 EFServer.refresh_token = refresh_token
 EFServer.revoke_token = revoke_token
+EFServer.tokens_from_file = tokens_from_file
 
 # User Actions
 EFServer.list_users = list_users

--- a/expfactory/utils.py
+++ b/expfactory/utils.py
@@ -42,6 +42,9 @@ import sys
 import os
 import re
 
+# match any letter, upper or lowercase, number and dash/underscore
+token_regex = "^[A-Za-z0-9_-]*$"
+
 ################################################################################
 # io utils
 ################################################################################

--- a/expfactory/utils.py
+++ b/expfactory/utils.py
@@ -204,9 +204,13 @@ def write_json(json_obj, filename, mode="w"):
     return filename
 
 
-def read_file(filename, mode="r"):
-    with open(filename, mode) as filey:
-        data = filey.read()
+def read_file(filename, mode="r", readlines=False):
+    if readlines:
+        with open(filename, mode) as filey:
+            data = filey.readlines()
+    else:
+        with open(filename, mode) as filey:
+            data = filey.read()
     return data
 
 

--- a/expfactory/version.py
+++ b/expfactory/version.py
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 
-__version__ = "3.2.12"
+__version__ = "3.2.13"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "expfactory"


### PR DESCRIPTION
Signed-off-by: vsoch <vsoch@users.noreply.github.com>

**Description of the Pull Request (PR):**

This PR will be early work to address #154 - and the branch can be tested as follows. First, create a dummy dockerfile that uses this branch, e.g., I could run `docker run -v $PWD:/data quay.io/vanessa/expfactory-builder build test-task` and then just change the branch:

```dockerfile
FROM quay.io/vanessa/expfactory-builder:base

########################################
# Configure
########################################

ENV EXPFACTORY_STUDY_ID expfactory
ENV EXPFACTORY_SERVER localhost
ENV EXPFACTORY_CONTAINER true
ENV EXPFACTORY_DATA /scif/data
ENV EXPFACTORY_DATABASE filesystem
ENV EXPFACTORY_HEADLESS false
ENV EXPFACTORY_BASE /scif/apps
 
ADD startscript.sh /startscript.sh
RUN chmod u+x /startscript.sh

WORKDIR /opt 
RUN git clone -b add/custom-tokens https://github.com/expfactory/expfactory
WORKDIR expfactory 
RUN cp script/nginx.gunicorn.conf /etc/nginx/sites-enabled/default && \
    cp script/nginx.conf /etc/nginx/nginx.conf
RUN mkdir -p /scif/data # saved data
RUN mkdir -p /scif/apps # experiments 
RUN mkdir -p /scif/logs # gunicorn logs 
RUN python3 -m pip install gunicorn
RUN cp expfactory/config_dummy.py expfactory/config.py && \
    chmod u+x /opt/expfactory/script/generate_key.sh && \
    /bin/bash /opt/expfactory/script/generate_key.sh /opt/expfactory/expfactory/config.py
RUN python3 setup.py install
RUN python3 -m pip install pyaml    pymysql psycopg2-binary
RUN apt-get clean          # tests, mysql,  postgres

########################################
# Experiments
########################################


LABEL EXPERIMENT_test-task /scif/apps/test-task
WORKDIR /scif/apps
RUN expfactory install https://github.com/expfactory-experiments/test-task

ENTRYPOINT ["/bin/bash", "/startscript.sh"]
EXPOSE 5000
EXPOSE 80
```
build it
```bash
$ docker build --no-cache -t experiment .
``
And then you can start it headless (or start it without detached and open another terminal to interact with it - up to you!)

```bash
docker run --name experiment -v $PWD/:/scif/data -d -p 80:80 experiment start
```

Now we can execute commands to interact with the install inside. E.g., list users

```bash
docker exec experiment expfactory users --list
```
there should be a command for `--tokens` so we can create a text file with line separated tokens (comments are okay)

```
# tokens.txt
# this is a comment
AAAAAA
BBBBBB
```
the present working directory is bound to /data so let's ask expfactory to add users from the tokens file there (from the container's point of view):

```
docker exec experiment expfactory users --tokens /scif/data/tokens.txt
2 users existing or generated from file.
```
You should then be able to see the data directories in expfactory in the PWD:

```bash
$ ls expfactory/
AAAAAA  BBBBBB
```

And also login via the interface with the tokens (I couldn't test this because I rigorously block cookies)! Also note a more complete variation of these instructions will be added to the expfactory.github.io docs, [shown here](https://github.com/expfactory/expfactory.github.io/pull/21/files#diff-2fdc78ef28c6b9cc62b7d0cf853f6ac44eb943cb37cf517e564e95ec5d684a14R209-R233)