### PR TITLE
Fixed problem with Windows characters.

### DIFF
--- a/expfactory/cli/build.py
+++ b/expfactory/cli/build.py
@@ -81,7 +81,7 @@ def main(args, parser, subparser):
     # Add local experiments to library, first preference
     local_installs = 0
     for experiment in experiments:
-        if os.path.exists(experiment):
+        if os.path.exists(os.path.abspath((experiment)):
 
             # Strip trailing slashes
             experiment = experiment.rstrip(os.sep)

--- a/expfactory/cli/install.py
+++ b/expfactory/cli/install.py
@@ -66,7 +66,7 @@ def main(args, parser, subparser):
     if valid is True:
 
         # Local Install
-        if os.path.exists(source):
+        if os.path.exists(os.path.abspath(source)):
             config = load_experiment(source)
             source = os.path.abspath(source)
         else:
@@ -124,7 +124,7 @@ def main(args, parser, subparser):
         with open(instruct, "w") as filey:
             filey.writelines(config["instructions"])
 
-    if not os.path.exists(dest):
+    if not os.path.exists(os.path.abspath(dest)):
         os.system("mkdir -p %s" % dest)
     else:
         if args.force is False:

--- a/expfactory/cli/logs.py
+++ b/expfactory/cli/logs.py
@@ -37,7 +37,7 @@ import os
 def main(args, parser, subparser):
 
     logs = "%s/expfactory.log" % EXPFACTORY_LOGS
-    if os.path.exists(logs):
+    if os.path.exists(os.path.abspath(logs)):
         if not args.tail:
             os.system("cat %s" % logs)
         else:

--- a/expfactory/cli/main.py
+++ b/expfactory/cli/main.py
@@ -53,7 +53,7 @@ def main(args, parser, subparser=None):
         bot.error("You must set a base of experiments with --base" % base)
         sys.exit(1)
 
-    if not os.path.exists(base):
+    if not os.path.exists(os.path.abspath(base)):
         bot.error("Base folder %s does not exist." % base)
         sys.exit(1)
 
@@ -66,7 +66,7 @@ def main(args, parser, subparser=None):
 
     # If defined and file exists, set runtime variables
     if args.vars is not None:
-        if os.path.exists(args.vars):
+        if os.path.exists(os.path.abspath(args.vars)):
             os.environ["EXPFACTORY_RUNTIME_VARS"] = args.vars
             os.environ["EXPFACTORY_RUNTIME_DELIM"] = args.delim
         else:

--- a/expfactory/database/filesystem.py
+++ b/expfactory/database/filesystem.py
@@ -108,10 +108,10 @@ def generate_user(self, subid=None):
         token = str(uuid.uuid4())
         subid = self.generate_subid(token=token)
 
-    if os.path.exists(self.data_base):  # /scif/data
+    if os.path.exists(os.path.abspath(self.data_base)):  # /scif/data
         data_base = "%s/%s" % (self.data_base, subid)
         # expfactory/00001
-        if not os.path.exists(data_base):
+        if not os.path.exists(os.path.abspath(data_base)):
             mkdir_p(data_base)
 
     return data_base
@@ -129,7 +129,7 @@ def finish_user(self, subid, ext="finished"):
     but if called by the user, it may not (e.g., xxxx-xxxx). We check
     for this to ensure it works in both places.
     """
-    if os.path.exists(self.data_base):  # /scif/data
+    if os.path.exists(os.path.abspath(self.data_base)):  # /scif/data
 
         # Only relevant to filesystem save - the studyid is the top folder
         if subid.startswith(self.study_id):
@@ -141,11 +141,11 @@ def finish_user(self, subid, ext="finished"):
         finished = "%s_%s" % (data_base, ext)
 
         # Participant already finished
-        if os.path.exists(finished):
+        if os.path.exists(os.path.abspath(finished)):
             self.logger.warning("[%s] is already finished: %s" % (subid, data_base))
 
         # Exists and can finish
-        elif os.path.exists(data_base):
+        elif os.path.exists(os.path.abspath(data_base)):
             os.rename(data_base, finished)
 
         # Not finished, doesn't exist
@@ -165,11 +165,11 @@ def restart_user(self, subid):
     the client users function, so we know subid does not start with the
     study identifer first
     """
-    if os.path.exists(self.data_base):  # /scif/data/<study_id>
+    if os.path.exists(os.path.abspath(self.data_base)):  # /scif/data/<study_id>
         data_base = "%s/%s" % (self.data_base, subid)
         for ext in ["revoked", "finished"]:
             folder = "%s_%s" % (data_base, ext)
-            if os.path.exists(folder):
+            if os.path.exists(os.path.abspath(folder)):
                 os.rename(folder, data_base)
                 self.logger.info("Restarting %s, folder is %s." % (subid, data_base))
 
@@ -197,7 +197,7 @@ def validate_token(self, token):
         subid = self.generate_subid(token=token)
         data_base = "%s/%s" % (self.data_base, subid)
         self.logger.info("Looking for data base %s" % data_base)
-        if not os.path.exists(data_base):
+        if not os.path.exists(os.path.abspath(data_base)):
             self.logger.info("Data base %s does not exist." % data_base)
             subid = None
     return subid
@@ -208,9 +208,9 @@ def refresh_token(self, subid):
     Refresh or generate a new token for a user. If the user is finished,
     this will also make the folder available again for using.
     """
-    if os.path.exists(self.data_base):  # /scif/data
+    if os.path.exists(os.path.abspath(self.data_base)):  # /scif/data
         data_base = "%s/%s" % (self.data_base, subid)
-        if os.path.exists(data_base):
+        if os.path.exists(os.path.abspath(data_base)):
             refreshed = "%s/%s" % (self.database, str(uuid.uuid4()))
             os.rename(data_base, refreshed)
             return refreshed
@@ -239,7 +239,7 @@ def get_finished_experiments(self, session):
         data_base = "%s/%s" % (self.data_base, subid)
 
         # Cut out early if nothing written yet
-        if not os.path.exists(data_base):
+        if not os.path.exists(os.path.abspath(data_base)):
             return finished
 
         # We only care about basename
@@ -263,14 +263,14 @@ def save_data(self, session, exp_id, content):
         data_base = "%s/%s" % (self.data_base, subid)
 
         # If not running in headless, ensure path exists
-        if not self.headless and not os.path.exists(data_base):
+        if not self.headless and not os.path.exists(os.path.abspath(data_base)):
             mkdir_p(data_base)
 
         # Conditions for saving:
         do_save = False
 
         # If headless with token pre-generated OR not headless
-        if self.headless and os.path.exists(data_base) or not self.headless:
+        if self.headless and os.path.exists(os.path.abspath(data_base)) or not self.headless:
             do_save = True
         if data_base.endswith(("revoked", "finished")):
             do_save = False
@@ -278,7 +278,7 @@ def save_data(self, session, exp_id, content):
         # If headless with token pre-generated OR not headless
         if do_save is True:
             data_file = "%s/%s-results.json" % (data_base, exp_id)
-            if os.path.exists(data_file):
+            if os.path.exists(os.path.abspath(data_file)):
                 self.logger.warning("%s exists, and is being overwritten." % data_file)
             write_json(content, data_file)
 
@@ -291,9 +291,9 @@ def init_db(self):
     """
     self.session = None
 
-    if not os.path.exists(self.data_base):
+    if not os.path.exists(os.path.abspath(self.data_base)):
         mkdir_p(self.data_base)
 
     self.database = "%s/%s" % (self.data_base, self.study_id)
-    if not os.path.exists(self.database):
+    if not os.path.exists(os.path.abspath(self.database)):
         mkdir_p(self.database)

--- a/expfactory/experiment.py
+++ b/expfactory/experiment.py
@@ -87,7 +87,7 @@ def load_experiment(folder, return_path=False):
     """
     fullpath = os.path.abspath(folder)
     config = "%s/config.json" % (fullpath)
-    if not os.path.exists(config):
+    if not os.path.exists(os.path.abspath(config)):
         bot.error("config.json could not be found in %s" % (folder))
         config = None
     if return_path is False and config is not None:

--- a/expfactory/testing/test_client.py
+++ b/expfactory/testing/test_client.py
@@ -96,7 +96,7 @@ class TestClient(unittest.TestCase):
                 "https://github.com/expfactory-experiments/test-task",
             ]
         )
-        self.assertTrue(os.path.exists("%s/test-task" % self.tmpdir))
+        self.assertTrue(os.path.exists(os.path.abspath("%s/test-task" % self.tmpdir)))
 
 
 if __name__ == "__main__":

--- a/expfactory/validator/experiments.py
+++ b/expfactory/validator/experiments.py
@@ -102,7 +102,7 @@ class ExperimentValidator:
         """
         config = "%s/config.json" % folder
         name = os.path.basename(folder)
-        if not os.path.exists(config):
+        if not os.path.exists(os.path.abspath(config)):
             return notvalid("%s: config.json not found." % (folder))
 
         # Load the config

--- a/expfactory/validator/library.py
+++ b/expfactory/validator/library.py
@@ -74,7 +74,7 @@ class LibraryValidator:
         self.metadata = {}
         uid = os.path.basename(expfile).strip(".md")
 
-        if os.path.exists(expfile):
+        if os.path.exists(os.path.abspath(expfile)):
             with open(expfile, "r") as stream:
                 docs = yaml.load_all(stream, Loader=yaml.SafeLoader)
                 for doc in docs:

--- a/expfactory/variables.py
+++ b/expfactory/variables.py
@@ -125,7 +125,7 @@ def generate_runtime_vars(variable_file=None, sep=","):
             variable_file = EXPFACTORY_RUNTIME_VARS
 
     if variable_file is not None:
-        if not os.path.exists(variable_file):
+        if not os.path.exists(os.path.abspath(variable_file)):
             bot.warning("%s is set, but not found" % variable_file)
             return variable_file
 


### PR DESCRIPTION
**Description of the Pull Request (PR):**

We had an issue with people using Windows entering invisible characters as part of the paths given as parameters when deploying. os.path.exists() assumes the weird characters are part of the path and return False for otherwise existing files and directories. I added a call to os.path.abspath() globally to address this problem. Please consider merging and further using for future os.path.exists()-calls. Thank you.